### PR TITLE
adds back the index name for metadata

### DIFF
--- a/q2_ancombc/_method.py
+++ b/q2_ancombc/_method.py
@@ -113,5 +113,5 @@ def ancombc(table: pd.DataFrame,
         summary = pd.read_csv(summary_fp, index_col=0)
         
         # del summary['diff_abn']  # remove this field for now ...
-        # summary.index.name = "featureid"
+        summary.index.set_names("feature-id", inplace=True)
         return summary


### PR DESCRIPTION
There is an issue where q2-ancom-bc isn't loading metadata (see https://forum.qiime2.org/t/ancom-bc-plugin-potential-bug/21352/3)

This should I think solve the issue 